### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,4 +1,6 @@
 name: Development branches
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/bpm-crafters/process-engine-worker/security/code-scanning/3](https://github.com/bpm-crafters/process-engine-worker/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow only performs read operations (e.g., checking out code, setting up Java, and running Maven commands), the minimal required permission is `contents: read`. This ensures that the workflow has only the permissions it needs to function correctly, reducing the risk of unintended actions.

The `permissions` block will be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
