### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,5 +1,9 @@
 name: Produces and releases artifacts
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/bpm-crafters/process-engine-worker/security/code-scanning/2](https://github.com/bpm-crafters/process-engine-worker/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the operations in the workflow, the following permissions are needed:
- `contents: read` for accessing the repository's contents.
- `packages: write` for deploying artifacts to Maven Central.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
