### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -3,6 +3,8 @@ on:
   milestone:
     types: [closed]
 name: Milestone Closure
+permissions:
+  contents: write
 jobs:
   create-release-notes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/bpm-crafters/process-engine-worker/security/code-scanning/1](https://github.com/bpm-crafters/process-engine-worker/security/code-scanning/1)

To fix the issue, we need to explicitly define a `permissions` block in the workflow. Since the workflow involves reading repository contents and creating a draft release, we will grant `contents: read` and `contents: write` permissions. These permissions are the minimum required for the workflow to function correctly. The `permissions` block will be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
