### PR TITLE
refactor: generate spring metadata-files & update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ build/
 ### DEV
 _tmp/
 .repository/
+.claude

--- a/README.md
+++ b/README.md
@@ -171,7 +171,10 @@ ZEEBE_CLIENT_ID=..
 ZEEBE_CLIENT_SECRET=...
 ```
 
-After starting application, you can either use Open API endpoints or just run the 
+After starting application, you can either use Open API endpoints or just run the
 HTTP client tests using your IntelliJ, located in the example directory.
 
-Don't forget to first deploy the process! Either manually via operate / modeler, or with the HTTP client script: c8-deploy-process.http
+Don't forget to first deploy the process! 
+Either manually via operate / modeler, or with the HTTP client script: 
+c8-deploy-process.http
+

--- a/docs/process-engine-worker.md
+++ b/docs/process-engine-worker.md
@@ -3,10 +3,10 @@ title: Process Engine Worker
 ---
 
 Process Engine Worker is an independent component built on top of Process Engine API in order to accelerate the development of agnostic workers
-for any process engine supported by Process Engine API in Spring Boot ecosystem. By doing so, it abstracts from specific worker clients and 
+for any process engine supported by Process Engine API in Spring Boot ecosystem. By doing so, it abstracts from specific worker clients and
 API and allows to build universal workers.
 
-First of all add the Process Engine Worker dependency to your projects classpath. In Maven add the following to you `pom.xml`:
+First of all add the Process Engine Worker dependency to your projects classpath. In Maven add the following to your `pom.xml`:
 
 ```xml
 <dependency>
@@ -72,8 +72,21 @@ is a checked exception, in order to comply with Spring behavior of not rolling b
 
 The worker method can be marked transactional by adding Spring or Jakarta EE transactional annotations to the method or to the worker class.
 If the annotation `@org.springframework.transaction.annotation.Transactional` with propagation `REQUIRES`, `REQUIRES_NEW`, `SUPPORTS` and `MANDATORY`
-is used, the library will execute the worker method and the completion of the external task via API in the same transaction. This will lead to 
+is used, the library will execute the worker method and the completion of the external task via API in the same transaction. This will lead to
 a transaction rollback, if the external task can't be completed (e.g. due to a network error).
+
+## Configuration
+
+You can configure the Process Engine Worker by adding the following properties to your `application.properties` or `application.yml`:
+
+```yaml
+dev:
+  bpm-crafters:
+    process-api:
+      worker:
+        registerProcessWorkers: true # Enable or disable automatic worker registration
+        completeTasksBeforeCommit: false # Determines whether tasks are completed before transaction commit
+```
 
 
 

--- a/examples/order-fulfillment/pom.xml
+++ b/examples/order-fulfillment/pom.xml
@@ -124,6 +124,18 @@
 
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-maven-plugin</artifactId>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -46,11 +46,6 @@
         <artifactId>mockito-kotlin</artifactId>
         <version>${mockito.version}</version>
       </dependency>
-      <dependency>
-        <groupId>com.tngtech.archunit</groupId>
-        <artifactId>archunit-junit5</artifactId>
-        <version>${archunit.version}</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -194,7 +189,7 @@
       <organizationUrl>https://holisticon.de</organizationUrl>
     </developer>
     <developer>
-      <id>__</id>
+      <id>stephanpelikan</id>
       <name>Stephan Pelikan</name>
       <roles>
         <role>Developer</role>
@@ -212,7 +207,7 @@
       <organizationUrl>https://phactum.at</organizationUrl>
     </developer>
     <developer>
-      <id>__</id>
+      <id>dominikhorn93</id>
       <name>Dominik Horn</name>
       <roles>
         <role>Developer</role>
@@ -221,13 +216,22 @@
       <organizationUrl>https://miragon.com</organizationUrl>
     </developer>
     <developer>
-      <id>__</id>
-      <name>Thomas Hinrichs</name>
+      <id>Hafflgav</id>
+      <name>Thomas Heinrichs</name>
       <roles>
         <role>Developer</role>
       </roles>
       <organization>Miragon</organization>
       <organizationUrl>https://miragon.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>emaarco</id>
+      <name>Marco Schäck</name>
+      <roles>
+        <role>Developer</role>
+      </roles>
+      <organization>Miragon</organization>
+      <organizationUrl>https://miragon.io</organizationUrl>
     </developer>
   </developers>
 </project>

--- a/spring-boot-starter/pom.xml
+++ b/spring-boot-starter/pom.xml
@@ -72,6 +72,11 @@
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
 
     <!-- Testing -->
     <dependency>
@@ -125,5 +130,34 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>kapt</id>
+            <goals>
+              <goal>kapt</goal>
+            </goals>
+            <configuration>
+              <sourceDirs>
+                <sourceDir>src/main/kotlin</sourceDir>
+              </sourceDirs>
+              <annotationProcessorPaths>
+                <annotationProcessorPath>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-configuration-processor</artifactId>
+                  <version>${spring-boot.version}</version>
+                </annotationProcessorPath>
+              </annotationProcessorPaths>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengine/worker/FailJobException.kt
+++ b/spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengine/worker/FailJobException.kt
@@ -4,7 +4,7 @@ import java.time.Duration
 
 /**
  * Exception for failing a job.
- * Allows to set the available retries and the backoff time for the retry.
+ * Allows setting the available retries and the backoff time for the retry.
  */
 class FailJobException(
   message: String,

--- a/spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengine/worker/configuration/ProcessEngineWorkerAutoConfiguration.kt
+++ b/spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengine/worker/configuration/ProcessEngineWorkerAutoConfiguration.kt
@@ -6,7 +6,6 @@ import dev.bpmcrafters.processengine.worker.registrar.metrics.ProcessEngineWorke
 import dev.bpmcrafters.processengine.worker.registrar.metrics.ProcessEngineWorkerMetricsNoOp
 import io.micrometer.core.instrument.MeterRegistry
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
@@ -25,11 +24,15 @@ class ProcessEngineWorkerAutoConfiguration {
    */
   @Bean
   @ConditionalOnMissingBean
-  fun defaultJacksonVariableConverter(objectMapper: ObjectMapper): VariableConverter = JacksonVariableConverter(objectMapper = objectMapper)
+  fun defaultJacksonVariableConverter(
+    objectMapper: ObjectMapper,
+  ): VariableConverter = JacksonVariableConverter(
+    objectMapper = objectMapper
+  )
 
   /**
    * Initializes parameter resolver.
-   * If you want to add your own parameter resolver, just create your own parameter resolver and expose it as bean. You might want
+   * If you want to add your own parameter resolver, create your own parameter resolver and expose it as bean. You might want
    * to register your own strategies using the [ParameterResolver.ParameterResolverBuilder#addStrategy] method.
    */
   @Bean
@@ -38,15 +41,15 @@ class ProcessEngineWorkerAutoConfiguration {
 
   /**
    * Initializes result resolver.
-   * If you want to add your own result resolver, just create you own result resolver and expose it as a bean. You might want
-   * to register you own strategy using [ResultResolver.ResultResolverBuilder#addStrategy] method.
+   * If you want to add your own result resolver, create your own result resolver and expose it as a bean.
+   * You might want to register your own strategy using the [ResultResolver.ResultResolverBuilder#addStrategy] method.
    */
   @Bean
   @ConditionalOnMissingBean
   fun defaultResultResolver() = ResultResolver.builder().build()
 
   /**
-   * Micrometer based metrics.
+   * Micrometer-based metrics.
    */
   @Bean
   @ConditionalOnBean(MeterRegistry::class)

--- a/spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengine/worker/configuration/ProcessEngineWorkerDeploymentAutoConfiguration.kt
+++ b/spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengine/worker/configuration/ProcessEngineWorkerDeploymentAutoConfiguration.kt
@@ -32,20 +32,23 @@ class ProcessEngineWorkerDeploymentAutoConfiguration {
   ) = ProcessDeployment(
     resourcePatternResolver = resourcePatternResolver,
     deploymentApi = deploymentApi,
-    processEngineWorkerDeploymentProperties = processEngineWorkerDeploymentProperties
+    deploymentProperties = processEngineWorkerDeploymentProperties
   )
 
   /**
    * Configures a trigger for auto-deployment triggered by application start event.
    */
   @ConditionalOnProperty(
-    prefix = ProcessEngineWorkerDeploymentProperties.PREFIX,
+    prefix = ProcessEngineWorkerDeploymentProperties.DEFAULT_PREFIX,
     name = ["enabled"],
     havingValue = "true",
     matchIfMissing = false
   )
   @Bean
-  fun autoDeploymentOnStartup(processDeployment: ProcessDeployment) =
-    AutoDeploymentOnStartup(processDeployment = processDeployment)
+  fun autoDeploymentOnStartup(
+    processDeployment: ProcessDeployment
+  ) = AutoDeploymentOnStartup(
+    processDeployment = processDeployment
+  )
 
 }

--- a/spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengine/worker/configuration/ProcessEngineWorkerDeploymentProperties.kt
+++ b/spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengine/worker/configuration/ProcessEngineWorkerDeploymentProperties.kt
@@ -1,31 +1,33 @@
 package dev.bpmcrafters.processengine.worker.configuration
 
-import dev.bpmcrafters.processengine.worker.configuration.ProcessEngineWorkerDeploymentProperties.Companion.PREFIX
+import dev.bpmcrafters.processengine.worker.configuration.ProcessEngineWorkerDeploymentProperties.Companion.DEFAULT_PREFIX
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.validation.annotation.Validated
 
 /**
  * Configuration properties for the deployment feature.
  */
-@ConfigurationProperties(prefix = PREFIX)
-class ProcessEngineWorkerDeploymentProperties(
+@Validated
+@ConfigurationProperties(prefix = DEFAULT_PREFIX)
+data class ProcessEngineWorkerDeploymentProperties(
   /**
    * Pattern to scan for BPMN resources.
    */
-  val bpmnResourcePattern: String = "classpath*:/**/*.bpmn",
+  var bpmnResourcePattern: String = "classpath*:/**/*.bpmn",
   /**
    * Pattern to scan fo DMN resources.
    */
-  val dmnResourcePattern: String = "classpath*:/**/*.dmn",
+  var dmnResourcePattern: String = "classpath*:/**/*.dmn",
   /**
    * Flag to control if the feature is active, defaults to `false`.
    */
-  val enabled: Boolean = false,
+  var enabled: Boolean = false,
   /**
    * Deployment timeout, defaults to 30 seconds.
    */
-  val deploymentTimeoutInSeconds: Long = 30,
+  var deploymentTimeoutInSeconds: Long = 30,
 ) {
   companion object {
-    const val PREFIX = ProcessEngineWorkerProperties.PREFIX + ".deployment"
+    const val DEFAULT_PREFIX = ProcessEngineWorkerProperties.DEFAULT_PREFIX + ".deployment"
   }
 }

--- a/spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengine/worker/configuration/ProcessEngineWorkerProperties.kt
+++ b/spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengine/worker/configuration/ProcessEngineWorkerProperties.kt
@@ -1,17 +1,25 @@
 package dev.bpmcrafters.processengine.worker.configuration
 
-import dev.bpmcrafters.processengine.worker.configuration.ProcessEngineWorkerProperties.Companion.PREFIX
+import dev.bpmcrafters.processengine.worker.configuration.ProcessEngineWorkerProperties.Companion.DEFAULT_PREFIX
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.validation.annotation.Validated
 
 /**
  * Configuration properties allowing simple switch off/on of auto-registration.
  */
-@ConfigurationProperties(prefix = PREFIX)
+@Validated
+@ConfigurationProperties(prefix = DEFAULT_PREFIX)
 data class ProcessEngineWorkerProperties(
-  val registerProcessWorkers: Boolean = true,
-  val completeTasksBeforeCommit: Boolean = false,
+  /**
+   * Determines whether the workers are automatically registered.
+   */
+  var registerProcessWorkers: Boolean = true,
+  /**
+   * Determines whether tasks are completed before transaction commit.
+   */
+  var completeTasksBeforeCommit: Boolean = false,
 ) {
   companion object {
-    const val PREFIX = "dev.bpm-crafters.process-api.worker"
+    const val DEFAULT_PREFIX = "dev.bpm-crafters.process-api.worker"
   }
 }

--- a/spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengine/worker/process/AutoDeploymentOnStartup.kt
+++ b/spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengine/worker/process/AutoDeploymentOnStartup.kt
@@ -4,7 +4,7 @@ import org.springframework.boot.context.event.ApplicationStartedEvent
 import org.springframework.context.ApplicationListener
 
 /**
- * Trigger to deploy resources on start-up of application.
+ * Trigger to deploy resources (for instance, processes) on start-up of the application.
  * @since 0.5.0
  */
 class AutoDeploymentOnStartup (

--- a/spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengine/worker/process/ProcessDeployment.kt
+++ b/spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengine/worker/process/ProcessDeployment.kt
@@ -20,7 +20,7 @@ private val logger = KotlinLogging.logger {}
 open class ProcessDeployment(
   private val resourcePatternResolver: ResourcePatternResolver,
   private val deploymentApi: DeploymentApi,
-  private val processEngineWorkerDeploymentProperties: ProcessEngineWorkerDeploymentProperties
+  private val deploymentProperties: ProcessEngineWorkerDeploymentProperties
 ) {
 
   /**
@@ -29,8 +29,8 @@ open class ProcessDeployment(
   open fun deployResources(): DeploymentInformation? {
     val namedResources = buildList<Resource> {
       try {
-        addAll(resourcePatternResolver.getResources(processEngineWorkerDeploymentProperties.bpmnResourcePattern))
-        addAll(resourcePatternResolver.getResources(processEngineWorkerDeploymentProperties.dmnResourcePattern))
+        addAll(resourcePatternResolver.getResources(deploymentProperties.bpmnResourcePattern))
+        addAll(resourcePatternResolver.getResources(deploymentProperties.dmnResourcePattern))
       } catch (e: IOException) {
         logger.warn(e) { "PROCESS-ENGINE-WORKER-051: Failed to load resources for deployment." }
       }
@@ -42,7 +42,7 @@ open class ProcessDeployment(
 
     return deploymentApi.deploy(
       DeployBundleCommand(resources = namedResources)
-    ).get(processEngineWorkerDeploymentProperties.deploymentTimeoutInSeconds, TimeUnit.SECONDS)
+    ).get(deploymentProperties.deploymentTimeoutInSeconds, TimeUnit.SECONDS)
       .also { deploymentResult ->
         logger.info { "PROCESS-ENGINE-WORKER-050: Deployed ${namedResources.size} resources with key ${deploymentResult.deploymentKey}." }
       }

--- a/spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengine/worker/registrar/ProcessEngineStarterRegistrar.kt
+++ b/spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengine/worker/registrar/ProcessEngineStarterRegistrar.kt
@@ -7,19 +7,16 @@ import dev.bpmcrafters.processengine.worker.ProcessEngineWorker.Completion.BEFOR
 import dev.bpmcrafters.processengine.worker.ProcessEngineWorker.Completion.DEFAULT
 import dev.bpmcrafters.processengine.worker.configuration.ProcessEngineWorkerAutoConfiguration
 import dev.bpmcrafters.processengine.worker.configuration.ProcessEngineWorkerProperties
-import dev.bpmcrafters.processengine.worker.configuration.ProcessEngineWorkerProperties.Companion.PREFIX
+import dev.bpmcrafters.processengine.worker.configuration.ProcessEngineWorkerProperties.Companion.DEFAULT_PREFIX
 import dev.bpmcrafters.processengineapi.task.*
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.beans.factory.config.BeanPostProcessor
 import org.springframework.boot.autoconfigure.AutoConfiguration
-import org.springframework.boot.autoconfigure.AutoConfigureAfter
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Lazy
 import org.springframework.transaction.support.TransactionTemplate
 import java.lang.reflect.Method
 import java.util.concurrent.ExecutionException
-
 
 private val logger = KotlinLogging.logger {}
 
@@ -28,7 +25,7 @@ private val logger = KotlinLogging.logger {}
  * @since 0.0.3
  */
 @AutoConfiguration(after = [ProcessEngineWorkerAutoConfiguration::class])
-@ConditionalOnProperty(prefix = PREFIX, name = ["enabled"], havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(prefix = DEFAULT_PREFIX, name = ["enabled"], havingValue = "true", matchIfMissing = true)
 class ProcessEngineStarterRegistrar(
   private val processEngineWorkerProperties: ProcessEngineWorkerProperties,
   @param:Lazy


### PR DESCRIPTION
Currently no `spring-configuration-metadata.json` file is generated. This has the effect that developers wont get autocompletion when trying to configure the library / property-classes in `application.yml` or `.properties`

This MR solves this. Therefore it adapts the property-classes. It makes them data-classes with `var`properties

This leads to the fact, that we are loosing immutability of the properties - but win developer-experience for configuration(s). So a trade-off we should decide about (what is more worth in this case)
