### PR TITLE
feat: support null values in PayloadSupplier for worker (#268)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <properties>
     <spring-boot.version>3.5.7</spring-boot.version>
-    <process-engine-api.version>1.4</process-engine-api.version>
+    <process-engine-api.version>1.5-SNAPSHOT</process-engine-api.version>
     <process-engine-adapters-c7.version>2025.11.1</process-engine-adapters-c7.version>
     <process-engine-adapters-c8.version>2025.11.1</process-engine-adapters-c8.version>
     <!-- TEST -->

--- a/spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengine/worker/registrar/ParameterResolutionStrategy.kt
+++ b/spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengine/worker/registrar/ParameterResolutionStrategy.kt
@@ -18,7 +18,7 @@ interface ParameterResolutionStrategy : Predicate<Parameter>, Function<Parameter
   data class Wrapper(
     val parameter: Parameter,
     val taskInformation: TaskInformation,
-    val payload: Map<String, Any>,
+    val payload: Map<String, Any?>,
     val variableConverter: VariableConverter,
     val taskCompletionApi: ServiceTaskCompletionApi
   )

--- a/spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengine/worker/registrar/ParameterResolver.kt
+++ b/spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengine/worker/registrar/ParameterResolver.kt
@@ -14,7 +14,7 @@ open class ParameterResolver private constructor(
 ) {
   companion object {
 
-    fun Map<String, Any>.toVariableList(): String {
+    fun Map<String, Any?>.toVariableList(): String {
       return if (this.isEmpty()) {
         "no process variables"
       } else {
@@ -91,7 +91,7 @@ open class ParameterResolver private constructor(
   open fun createInvocationArguments(
     method: Method,
     taskInformation: TaskInformation,
-    payload: Map<String, Any>,
+    payload: Map<String, Any?>,
     variableConverter: VariableConverter,
     taskCompletionApi: ServiceTaskCompletionApi
   ): Array<Any?> {

--- a/spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengine/worker/registrar/ProcessEngineStarterRegistrar.kt
+++ b/spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengine/worker/registrar/ProcessEngineStarterRegistrar.kt
@@ -173,7 +173,7 @@ class ProcessEngineStarterRegistrar(
    */
   private fun workerAndApiInvocation(
     taskInformation: TaskInformation,
-    payload: Map<String, Any>,
+    payload: Map<String, Any?>,
     actionWithResult: TaskHandlerWithResult,
   ): Any? {
     logger.trace { "PROCESS-ENGINE-WORKER-015: invoking external task worker for ${taskInformation.taskId}" }
@@ -265,7 +265,7 @@ class ProcessEngineStarterRegistrar(
   /**
    * Task handler as a function.
    */
-  fun interface TaskHandlerWithResult : (TaskInformation, Map<String, Any>) -> Any?
+  fun interface TaskHandlerWithResult : (TaskInformation, Map<String, Any?>) -> Any?
 
   /**
    * Failure retry information.


### PR DESCRIPTION
- Updated process-engine-api dependency to 1.5-SNAPSHOT
- Updated workerAndApiInvocation to accept Map<String, Any?>
- Updated TaskHandlerWithResult to handle nullable values
- Worker compiles successfully

Related to bpm-crafters/process-engine-api#268