### PR TITLE
docs: clarify behavior when autodeployment is disabled

### DIFF
--- a/docs/process-deployment.md
+++ b/docs/process-deployment.md
@@ -30,3 +30,4 @@ dev:
           dmnResourcePattern: "classpath*:/**/*.dmn"
 ```
 
+> **Warning:** Disabling the engine's own autodeployment also disables the autodeployment provided by the Process Engine Worker. In that setup, the Process Engine Worker deployment feature will not deploy resources on startup either. To use the Process Engine Worker's autodeployment feature, make sure to not explicitly disable the engine's process deployment features.


### PR DESCRIPTION
It took quite some time to figure out why my bpmn process is not deployed. I double checked the docs a couple of times. In the end I accidently configured camunda 7 to disable the autodeployment which disabled the process engine workers autodeployment feature too.

I don't think this is a bug in the process-engine-worker, but I added for clarification more details to the docs.