### PR TITLE
chore(ci): pin github actions to exact version tags

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -24,14 +24,14 @@ jobs:
     steps:
       # Checkout the code
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
 
       - name: Expose branch name
         run: echo ${{ github.ref }}
 
       # Setup JDK and Maven
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.3.0
         with:
           java-version-file: .java-version
           distribution: 'zulu'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,11 +15,11 @@ jobs:
     name: Build and run tests
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
 
       # Setup JDK and .m2/settings.xml
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.3.0
         with:
           java-version-file: .java-version
           distribution: 'zulu'

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@master
+        uses: actions/checkout@v7.0.0
       - name: Create Release Notes Markdown
         uses: docker://ghcr.io/rohwerj/release-notes-generator-action:v1.0.0
         env:
@@ -27,7 +27,7 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
       - name: Create a Draft Release Notes on GitHub
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@v1.1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:


### PR DESCRIPTION
## What
Pin all external GitHub Actions in the workflow files to **exact version tags** (`@vX.Y.Z`) instead of moving references (major-only `@vX`, or branch refs like `@master`).

## Why
Moving refs silently absorb upstream changes on every run, which makes CI non-reproducible and exposes the pipeline to **major drift** and unexpected behavior changes. Pinning to a full semver tag freezes the action to a known, reviewable version while still allowing intentional, explicit upgrades (e.g. via Dependabot).

## Mapping (before → after)

| Action | File(s) | Before | After |
|---|---|---|---|
| `actions/checkout` | development.yml, master.yml | `@v7` | `@v7.0.0` |
| `actions/checkout` | release-notes.yml | `@master` ⚠️ | `@v7.0.0` |
| `actions/setup-java` | development.yml, master.yml | `@v5` | `@v5.3.0` |
| `actions/create-release` | release-notes.yml | `@v1` | `@v1.1.4` |

⚠️ **`actions/checkout@master`** in `release-notes.yml` was a **branch reference** — the highest-risk case, since it tracks the action's development branch and could change at any time. It is now pinned to `v7.0.0` (matching the version already used in the other workflows).

All version bumps stay within the same major version, so no breaking changes are expected.

Left untouched (already exact / not a moving ref):
- `docker://ghcr.io/rohwerj/release-notes-generator-action:v1.0.0` — already an exact tag.
- Commented-out `codecov/codecov-action` lines — dead code, not executed.
- Local reusable workflows (`./.github/...`) — none present.

## Verification
- `actionlint` runs clean (only pre-existing, unrelated shellcheck warnings in the `release-notes.yml` `run:` script remain — not touched here).
- Grep confirms no moving refs remain in any active `uses:` line.
- Changes are CI-YAML-only (no source changes), so the Maven build is unaffected.

## Note
Tag-pinning protects against major drift. The next hardening step would be **full-SHA pinning** (`@<40-char-sha>`), which also protects against a tag being re-pointed upstream — that could be a follow-up.