### PR TITLE
Fix C8 self-managed example connectivity (#185)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,14 @@ To run it, you have several options:
 
 ### Running locally using self-managed Camunda 8
 
-1. Start `docker-compose.yaml` (this will start containerized Zeebe locally)
+1. Start `docker-compose.yaml` (this starts the consolidated Camunda 8 orchestration
+   container — Zeebe + Operate + Tasklist — plus Elasticsearch): `docker compose up -d`
+   from the `examples/order-fulfillment` directory.
 2. Start `FulfillmentProcessApplication` activating Spring profile `c8sm`.
+
+The Operate / Tasklist UI is available at http://localhost:8088 (login `demo` / `demo`).
+The application's own REST API / OpenAPI UI runs on http://localhost:8080 — this is why
+the orchestration container is published on `8088` rather than `8080`.
 
 ### Running using Camunda SaaS
 

--- a/examples/order-fulfillment/src/main/resources/application-c8sm.yml
+++ b/examples/order-fulfillment/src/main/resources/application-c8sm.yml
@@ -24,15 +24,14 @@ camunda:
     enabled: false
   client:
     mode: self-managed
+    grpc-address: http://localhost:26500
+    rest-address: http://localhost:8088
     auth:
       username: demo
       password: demo
     worker:
       defaults:
         enabled: true
-    tasklist:
-      base-url: http://localhost:8081/tasklist
-    rest-address: http://localhost:8081
 
 logging:
   level:


### PR DESCRIPTION
References #185.

### Cause
The C8.8 `docker-compose.yaml` migration publishes the consolidated `orchestration`
container's REST API/UI on host port **8088** (the example app itself uses 8080), but
`application-c8sm.yml` still pointed the Camunda client at the old port **8081** and no
longer set a gRPC address — so process deployment and every REST call hit a dead port.

### Fix
- `application-c8sm.yml`: `rest-address: http://localhost:8088` (was `:8081`), add explicit
  `grpc-address: http://localhost:26500`, drop the obsolete `tasklist.base-url`.
- `README.md`: document the `8080` (app) vs `8088` (engine UI, `demo`/`demo`) split.

### Verified
`docker compose up` brings up a healthy `camunda/camunda:8.8.2`; REST API v2 on `:8088`
returns 200 while the old `:8081` is connection-refused; the app boots and configures the
Camunda basic-auth client against `:8088`.

### Remaining blocker but out of scope
The example still can't fully start on `develop`: the c8 adapter is pinned to **2026.07.1**,
which is built for **Spring Boot 4 / Camunda 8.9**, while this repo runs **Spring Boot 3.5.16**
(duplicate `healthContributorRegistry` bean + `httpclient5` method mismatch). 
This is addressed in Issue: #267 
